### PR TITLE
controller 生成時、使わないファイルまでできないように設定する

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,9 @@ module Kajaeru
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.generators do |g|
+      g.assets  false
+      g.helper  false
+    end
   end
 end


### PR DESCRIPTION
# 概要

`rails generage controller` コマンドを実行した際に、使用する予定のない helper , assets ファイルを生成しないように設定します。
http://guides.rubyonrails.org/configuring.html#configuring-generators
# Issue
#5
# TODO
- [x] `config/application.rb` の書き換え
- [x] ためしに generate してみる
# ためした結果

``` sh
yucao24hours@yucao24hours ~/work/yochiyochi/rails_projects/kajaeru
☺  rails generate controller foobar index new edit show                                                                           2.0.0-rc2 (set by /Users/yucao24hours/work/yochiyochi/rails_projects/.ruby-version) file-generate-setting ✔
      create  app/controllers/foobar_controller.rb
       route  get "foobar/show"
       route  get "foobar/edit"
       route  get "foobar/new"
       route  get "foobar/index"
      invoke  haml
      create    app/views/foobar
      create    app/views/foobar/index.html.haml
      create    app/views/foobar/new.html.haml
      create    app/views/foobar/edit.html.haml
      create    app/views/foobar/show.html.haml
```
