### PR TITLE
データ取り込み時のidの型をstringにする

### DIFF
--- a/lib/batch/insert_to_members_from_github_contributors.rb
+++ b/lib/batch/insert_to_members_from_github_contributors.rb
@@ -15,8 +15,8 @@ contributors.each do |contributor|
   author = contributor['author']
   next if Member.find_by(uid: author['id'])
   member = Member.create!(
-  	nickname: author['login'], 
-  	provider: 'github', 
-  	uid: author['id'], 
-  	image: author['avatar_url'])
+    nickname: author['login'],
+    provider: 'github',
+    uid: author['id'].to_s,
+    image: author['avatar_url'])
 end


### PR DESCRIPTION
idの型がintegerでrubyで処理されたため、postgresqlでは取り込みに失敗する。
idの型をstringとして設定するように修正する。
