### PR TITLE
「新しく投票する」ときと「投票を編集する」ときにもアイコンを表示させる

### DIFF
--- a/app/views/votes/_form.html.haml
+++ b/app/views/votes/_form.html.haml
@@ -6,6 +6,7 @@
     - @members.each do |member|
       %li
         = f.radio_button :voted_member_id, member.id
+        = image_tag member.image, alt: member.nickname, size: '40x40'
         = member.nickname
   %div
     = f.label :comment, '推薦コメント(任意)'


### PR DESCRIPTION
34回のミートアップで @katorie さんと @upinetree さんがペアプロで実装してくれた内容です。
# 概要

現状、「新しく投票する」ときと「投票を編集する」ときには Github アカウントしか表示されていないですが、ここにそのアカウントのアイコン画像も表示されるように変更しました。
# Trello

https://trello.com/c/3lkD2OjJ
