### PR TITLE
vendor/bundle を使用しない運用にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Kajaeruのログイン機能はGithub APIのOauthを利用するため、[こち
 git clone https://github.com/yochiyochirb/kajaeru.git
 cd kajaeru
 
-bundle install --path vendor/bundle
+bundle install
 
 cp config/database.yml.sample config/database.yml
 


### PR DESCRIPTION
# ブランチの概要
`vendor/bundle` を必須としていましたが、個々の環境に任せることにします。
該当箇所をマニュアルから削除します。

# Trello
https://trello.com/c/gv3OV1DQ/28-bundle-install-path