### PR TITLE
GitHub 認証用コードを figaro で管理するようにした（dev のみ）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ doc/
 
 # database settings
 /config/database.yml
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :doc do
 end
 
 group :development do
+  gem 'figaro'
   gem 'quiet_assets'
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
     execjs (2.2.1)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    figaro (1.1.0)
+      thor (~> 0.14)
     haml (4.0.5)
       tilt
     haml-rails (0.5.3)
@@ -190,6 +192,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   coffee-rails (~> 4.0.0)
+  figaro
   haml-rails
   jbuilder (~> 1.2)
   jquery-rails

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Kajaeruのログイン機能はGithub APIのOauthを利用するため、[こち
   * http://localhost:3000/auth/github/callback
 
 ## 環境構築
+1.ローカルのターミナルで以下の操作を実行してください。
 
 ```sh
 git clone https://github.com/yochiyochirb/kajaeru.git
@@ -26,16 +27,27 @@ cd kajaeru
 bundle install --path vendor/bundle
 
 cp config/database.yml.sample config/database.yml
+cp config/application.yml.sample config/application.yml
 
 bundle exec rake db:create
 bundle exec rake db:migrate
 
 bundle exec rails runner lib/batch/insert_to_members_from_github_contributors.rb
+```
 
-# ex) bash,zsh
-export GITHUB_CLIENT_ID="XXXXXXXXX"         # Kajaeru用のClient IDを設定
-export GITHUB_CLIENT_SECRET="XXXXXXXXXXXXX" # Kajaeru用のClient Secretを設定
+2.`config/database.yml` を適宜修正してください。（基本的にはなにもしなくても動くはず）
 
+3.「事前準備」で取得した __Client ID__ と __Client Secret__ を`config/application.yml`に記載してください。`your_xxx` となっているところを、取得した値に置き換えるようになります。
+
+```yml
+# examples
+GITHUB_CLIENT_ID: 'ekjfksdifjikji3wsfalsd'               # Kajaeru用のClient IDを設定
+GITHUB_CLIENT_SECRET: '23jijvc9ui3jikjkk22k49vfjdk58uv'  # Kajaeru用のClient Secretを設定
+```
+
+4.サーバを起動します。
+
+```sh
 bundle exec rails server
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ cd kajaeru
 bundle install --path vendor/bundle
 
 cp config/database.yml.sample config/database.yml
+# condig/database.yml を自分の環境にあわせて適宜修正する（基本的には何もしなくても動くはず）
 cp config/application.yml.sample config/application.yml
 
 bundle exec rake db:create
@@ -35,9 +36,7 @@ bundle exec rake db:migrate
 bundle exec rails runner lib/batch/insert_to_members_from_github_contributors.rb
 ```
 
-2.`config/database.yml` を適宜修正してください。（基本的にはなにもしなくても動くはず）
-
-3.「事前準備」で取得した __Client ID__ と __Client Secret__ を`config/application.yml`に記載してください。`your_xxx` となっているところを、取得した値に置き換えるようになります。
+2.「事前準備」で取得した __Client ID__ と __Client Secret__ を`config/application.yml`に記載してください。`your_xxx` となっているところを、取得した値に置き換えるようになります。
 
 ```yml
 # examples
@@ -45,7 +44,7 @@ GITHUB_CLIENT_ID: 'ekjfksdifjikji3wsfalsd'               # Kajaeru用のClient I
 GITHUB_CLIENT_SECRET: '23jijvc9ui3jikjkk22k49vfjdk58uv'  # Kajaeru用のClient Secretを設定
 ```
 
-4.サーバを起動します。
+3.サーバを起動します。
 
 ```sh
 bundle exec rails server

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ bundle exec rails runner lib/batch/insert_to_members_from_github_contributors.rb
 
 ```yml
 # examples
-GITHUB_CLIENT_ID: 'ekjfksdifjikji3wsfalsd'               # Kajaeru用のClient IDを設定
-GITHUB_CLIENT_SECRET: '23jijvc9ui3jikjkk22k49vfjdk58uv'  # Kajaeru用のClient Secretを設定
+GITHUB_CLIENT_ID: 'aaaaaaaaaaaaaaaaaaaaaa'               # Kajaeru用のClient IDを設定
+GITHUB_CLIENT_SECRET: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'  # Kajaeru用のClient Secretを設定
 ```
 
 3.サーバを起動します。

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd kajaeru
 bundle install --path vendor/bundle
 
 cp config/database.yml.sample config/database.yml
-# condig/database.yml を自分の環境にあわせて適宜修正する（基本的には何もしなくても動くはず）
+# config/database.yml を自分の環境にあわせて適宜修正する（基本的には何もしなくても動くはず）
 cp config/application.yml.sample config/application.yml
 
 bundle exec rake db:create

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -1,0 +1,2 @@
+GITHUB_CLIENT_ID: 'your_github_client_id'
+GITHUB_CLIENT_SECRET: 'your_github_client_secret'


### PR DESCRIPTION
## ブランチの概要
開発時、omniauth で使う GitHub 認証用コードを毎回ローカルの環境変数に入れるのがめんどくさい、かといって zshrc に入れておくのもなんかきもちわるいので、figaro を使って設定できるようにしました。

[laserlemon/figaro](https://github.com/laserlemon/figaro)

README を書き換えておいたので、そちらの手順どおり `config/application.yml` にみなさま各自の認証コードを入れていただき、ログインできることを確認していただければと思います :bow: 