### PR TITLE
README に TravisCI の build status image を設置する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,13 @@
 # Kajaeru
 
-## 事前準備
+[![Build Status](https://travis-ci.org/yochiyochirb/kajaeru.svg?branch=master)](https://travis-ci.org/yochiyochirb/kajaeru)
 
-Kajaeruのログイン機能はGithub APIのOauthを利用するため、[こちら](https://github.com/settings/applications)より、Developer applicationsに登録し、Kajaeruのための __Client ID__ と __Client Secret__ を取得してください。
+## What is Kajaeru?
+Kajaeru is a web-based voting application to elect Ruby Kaja.
 
-### 設定内容サンプル
+About Ruby Kaja, see the [web page](http://kaja.rubyist.net/) for more information.
 
-`localhost:3000`を環境に応じて変更してください。
+## How to join
+Only Yochiyochi.rb members can join this project.
 
-* Application name（任意）
-  * kajaeru
-* Homepage URL
-  * http://localhost:3000
-* Description
-  * ruby kaja投票アプリ
-* Authorization callback URL
-  * http://localhost:3000/auth/github/callback
-
-## 環境構築
-1.ローカルのターミナルで以下の操作を実行してください。
-
-```sh
-git clone https://github.com/yochiyochirb/kajaeru.git
-cd kajaeru
-
-bundle install
-
-cp config/database.yml.sample config/database.yml
-# config/database.yml を自分の環境にあわせて適宜修正する（基本的には何もしなくても動くはず）
-cp config/application.yml.sample config/application.yml
-
-bundle exec rake db:create
-bundle exec rake db:migrate
-
-bundle exec rails runner lib/batch/insert_to_members_from_github_contributors.rb
-```
-
-2.「事前準備」で取得した __Client ID__ と __Client Secret__ を`config/application.yml`に記載してください。`your_xxx` となっているところを、取得した値に置き換えるようになります。
-
-```yml
-# examples
-GITHUB_CLIENT_ID: 'aaaaaaaaaaaaaaaaaaaaaa'               # Kajaeru用のClient IDを設定
-GITHUB_CLIENT_SECRET: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'  # Kajaeru用のClient Secretを設定
-```
-
-3.サーバを起動します。
-
-```sh
-bundle exec rails server
-```
-
-### herokuへのデプロイ
-
-herokuへデプロイするためには、以下コマンドにより環境変数を設定する必要があります。
-
-```sh
-heroku config:set GITHUB_CLIENT_ID="XXXXXXXXX"         # Kajaeru用のClient IDを設定
-heroku config:set GITHUB_CLIENT_SECRET="XXXXXXXXXXXXX" # Kajaeru用のClient Secretを設定
-```
-
-## 作業に入るまえに
-[Wiki](https://github.com/yochiyochirb/kajaeru/wiki) に開発ルールやスケジュールがまとめてありますので、ご一読ください。
+If you are Yochiyochi.rb member and want to improve Kajaeru with us, please read [wiki(Japanese)](https://github.com/yochiyochirb/kajaeru/wiki) at first.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-# Kajaeru
-
-[![Build Status](https://travis-ci.org/yochiyochirb/kajaeru.svg?branch=master)](https://travis-ci.org/yochiyochirb/kajaeru)
+# Kajaeru [![Build Status](https://travis-ci.org/yochiyochirb/kajaeru.svg?branch=master)](https://travis-ci.org/yochiyochirb/kajaeru)
 
 ## What is Kajaeru?
-Kajaeru is a web-based voting application to elect Ruby Kaja.
+Kajaeru is a web-based voting application to elect Ruby Kaja. ( "eru(選る)" is to select someone or something from among several in Japanese. )
 
 About Ruby Kaja, see the [web page](http://kaja.rubyist.net/) for more information.
 
 ## How to join
-Only Yochiyochi.rb members can join this project.
+Only Yochiyochi.rb members can join and send PRs to this project.
 
-If you are Yochiyochi.rb member and want to improve Kajaeru with us, please read [wiki(Japanese)](https://github.com/yochiyochirb/kajaeru/wiki) at first.
+If you are a Yochiyochi.rb member and want to improve Kajaeru with us, please read [wiki(Japanese)](https://github.com/yochiyochirb/kajaeru/wiki) at first.


### PR DESCRIPTION
## ブランチの概要
README の見やすいところに、master ブランチの Travis の build status がひとめでわかるアイコンを設置しました。

![statusicon](https://cloud.githubusercontent.com/assets/1979779/6977275/3c036910-d9f5-11e4-861c-4e86117c5a8f.png)

あと、README には「このアプリがどういうものなのか」をあらわす文章だけを書き、開発環境構築の詳しい手順についてはそのまま [wiki](https://github.com/yochiyochirb/kajaeru/wiki) に移動させました。

むだに英語で書いてますが特に意味はありません。（アプリ自体の国際化の対応予定もありません。）
単に私の趣味(？) だったので、日本語のほうがいいのでは、っということでしたら直します :japan: 

## Trello の対応カード
https://trello.com/c/PY3XMk1d