### PR TITLE
Ruby のバージョンを最新のもので固定した

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.0.0-p576
+  - 2.3.0
 before_script:
   - "cp ./config/database.yml.sample ./config/database.yml"
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.3.0'
 
 gem 'rails', '4.0.3'
 gem 'sass-rails', '~> 4.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,39 +2,37 @@ source 'https://rubygems.org'
 ruby '2.3.0'
 
 gem 'rails', '4.0.3'
-gem 'sass-rails', '~> 4.0.0'
-gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.0.0'
-gem 'jquery-rails'
-gem 'turbolinks'
-gem 'jbuilder', '~> 1.2'
-gem 'omniauth-github'
 gem 'haml-rails'
+gem 'jbuilder', '~> 1.2'
+gem 'jquery-rails'
+gem 'omniauth-github'
+gem 'sass-rails', '~> 4.0.0'
+gem 'turbolinks'
+gem 'uglifier', '>= 1.3.0'
+gem 'zocial-rails'
 
 group :doc do
   gem 'sdoc', require: false
 end
 
 group :development do
-  gem 'figaro'
-  gem 'quiet_assets'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'figaro'
+  gem 'quiet_assets'
   gem 'sqlite3'
-end
 
-group :test do
-  group :development do
-    gem 'rspec-rails'
-    gem 'pry-rails'
+  group :test do
     gem 'pry-nav'
+    gem 'pry-rails'
+    gem 'rspec-rails'
   end
 end
 
 group :production do
-  gem 'unicorn'
   gem 'pg'
   gem 'rails_12factor'
+  gem 'unicorn'
 end
 
-gem 'zocial-rails'


### PR DESCRIPTION
## やったこと
いつも新しい Ruby で開発をしていきたいので、Gemfile 内で Ruby のバージョンを固定するように（再び）しました。
（あと、Gemfile をいじったついでに gem の並び順をアルファベット順に sort したりしました。ついでですみません。）

## 対応する issue
connects to #93 
