### PR TITLE
seed.rb で STI の子モデルを作るときの余計な type 属性の指定を削除 (Closes #108)

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,7 +25,7 @@ Member.transaction do
   Member.all.map do |member|
     %w(candidate voter).map {|klass| klass.classify.constantize }
       .each do |klass|
-        klass.create!(member_id: member.id, type: "#{klass}")
+        klass.create!(member_id: member.id)
       end
   end
 end


### PR DESCRIPTION
connect to #108 