### PR TITLE
HoundCI の設定を変えた（メソッドチェーンの途中でのドットの位置）

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -116,11 +116,12 @@ Style/CommentAnnotation:
   - OPTIMIZE
   - HACK
   - REVIEW
+# NOTE メソッドチェーンの途中で改行するとき、ドットをどこに置くか
 Style/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
   Enabled: true
-  EnforcedStyle: trailing
+  EnforcedStyle: leading
   SupportedStyles:
   - leading
   - trailing


### PR DESCRIPTION
## やったこと

HoundCI のチェック項目で、メソッドチェーンの途中で改行するときにドットをどこに置くかの設定がありますが、それを「改行後の先頭」にしたかったのでそのとおりに変更しました。

yucao24hours のしゅみで変えてる感じがあるので、なにかご意見などありましたらお聞かせください。

（複数人での開発におけるこの手の設定ってどうやって落とし所を見つけたらいいかわからないので、どう決めたらいいかについても聞かせていただけると助かります :bee: ）

## 対応する issue
connects to #101