### PR TITLE
schema.rb を更新した

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,13 +13,13 @@
 
 ActiveRecord::Schema.define(version: 20150307085644) do
 
-  create_table "events", force: true do |t|
+  create_table "events", force: :cascade do |t|
     t.string   "name",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "members", force: true do |t|
+  create_table "members", force: :cascade do |t|
     t.string   "nickname",   null: false
     t.string   "provider",   null: false
     t.string   "uid",        null: false
@@ -30,14 +30,14 @@ ActiveRecord::Schema.define(version: 20150307085644) do
 
   add_index "members", ["nickname", "uid", "image"], name: "members_unique_index", unique: true
 
-  create_table "roles", force: true do |t|
+  create_table "roles", force: :cascade do |t|
     t.integer  "member_id",  null: false
     t.string   "type",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "votes", force: true do |t|
+  create_table "votes", force: :cascade do |t|
     t.text     "comment"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false


### PR DESCRIPTION
## やったこと

Rails 4.2 で入った `force: :cascade` に対応していなかったので、マイグレートしなおして push しました。

http://railsguides.jp/4_2_release_notes.html#active-record-%E4%B8%BB%E3%81%AA%E5%A4%89%E6%9B%B4%E7%82%B9

>create_tableが実行されるとき、SchemaDumperがforce: :cascadeを使うようになりました。これにより、外部キーが適切であればスキーマが再読み込みできるようになります。

## 対応する issue

なし


