### PR TITLE
開発時に OAuth application 登録をしなくて済むように OmniAuth のテストモードと mock を利用 (Closes #127)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,33 +2,18 @@ class SessionsController < ApplicationController
   def new
   end
 
+  # OAuth 認証時のコールバック先アクション
+  # NOTE development 環境では実際には OAuth 認証は行われない
+  #      詳しくは config/initializers/omniauth.rb を参照
   def callback
-    if Rails.env.production?
-      auth = request.env['omniauth.auth']
+    auth = request.env['omniauth.auth']
+    member = Member.find_by_provider_and_uid(auth['provider'], auth['uid'])
 
-      # NOTE 最初にバッチで GH organization のメンバーをすべて入れている前提で、新しく作ったりする
-      #      ことは想定していないため、find_or_create みたいなことはしていない
-      # NOTE 上記の理由から、ローカル環境で GH ログインをする際にはあらかじめバッチを実行しておく
-      #      必要がある（だから wiki の開発環境構築手順にそれが書いてある）。
-      #      しかし、実際のコードでは RAILS_ENV を見て分岐して、production でなければ特にそういった
-      #      手順をとらなくてもログインができるように、session には無理やり id をつめている。
-      #      session に手で id をつめるなら、そもそも /auth/github にいかなくていいし
-      #      GH OAutn app の登録はしなくていいと思うんだけど...
-      #      案としては、auth_path みたいなルーティングを作って、そのなかで RAILS_ENV を見て
-      #      redirect_to '/auth/github/' に向かせるのと（production）、def set_member_info_for_dev_and_test
-      #      みたいなアクションで session をつめるのと、かなあ。
-      member = Member.find_by_provider_and_uid(auth['provider'], auth['uid'])
-
-      if member
-        session[:user_id] = member.id
-        redirect_to root_path
-      else
-        redirect_to root_path, notice: 'You have no authorization.'
-      end
-    else
-      # テストデータでログインするため実質認証はしていない
-      session[:user_id] = 1
+    if member
+      session[:user_id] = member.id
       redirect_to root_path
+    else
+      redirect_to root_path, notice: 'You have no authorization.'
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
   #      詳しくは config/initializers/omniauth.rb を参照
   def callback
     auth = request.env['omniauth.auth']
-    member = Member.find_by_provider_and_uid(auth['provider'], auth['uid'])
+    member = Member.find_by(provider: auth['provider'], uid: auth['uid'])
 
     if member
       session[:user_id] = member.id

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,14 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :github, ENV['GITHUB_CLIENT_ID'], ENV['GITHUB_CLIENT_SECRET']
+
+  # NOTE 開発時に GitHub の OAuth application の登録が必須だと大変なので、
+  #      development 環境では実際に認証はせず OmniAuth の mock 機能を利用する
+  if Rails.env.development?
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+      provider: 'github',
+      uid: '11111',
+      info: { nickname: 'alice' }
+    )
+  end
 end

--- a/features/step_definitions/signin_steps.rb
+++ b/features/step_definitions/signin_steps.rb
@@ -1,11 +1,13 @@
 前提(/^GitHub アカウント "([^"]*)" でログインしている$/) do |account|
+  member = Member.find_by(nickname: account)
+
   OmniAuth.config.test_mode = true
 
   OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
-    provider: 'github',
-    uid: '11111',
+    provider: member.provider,
+    uid: member.uid,
     info: {
-      nickname: account
+      nickname: member.nickname
     }
   )
 

--- a/features/step_definitions/signin_steps.rb
+++ b/features/step_definitions/signin_steps.rb
@@ -3,9 +3,9 @@
 
   OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
     provider: 'github',
-    uid: '111111',
+    uid: '11111',
     info: {
-      nickname: "#{account}"
+      nickname: account
     }
   )
 

--- a/features/step_definitions/signin_steps.rb
+++ b/features/step_definitions/signin_steps.rb
@@ -1,5 +1,5 @@
 前提(/^GitHub アカウント "([^"]*)" でログインしている$/) do |account|
-  member = Member.find_by(nickname: account)
+  member = Member.find_by!(nickname: account)
 
   OmniAuth.config.test_mode = true
 


### PR DESCRIPTION
## やったこと

### 概要

#127 を実装しました。

- OmniAuth の mock 機能を使って `development` 環境で実際の OAuth 認証はしないように修正
- テストの `signin_steps` で `uid` の間違いがあったのを修正 (以前テストが落ちてた原因はこれ)
- `signin_steps` で mock を作っている箇所でハードコーディングをなくしてより柔軟に対応できるようにした。

### 説明

OmniAuth には Integration テスト用の機能として mock を用意して認証をフックする機能があります。
認証自体が不要なのであれば、開発時にもこの機能が使えそうだな、というのが背景です。

その機能の説明ページ
https://github.com/intridea/omniauth/wiki/Integration-Testing

`initializer` の中で、`development` 環境であればテストモードを有効にして mock を設定するようにしています。`test` 環境はテストの中で個別に設定した方がいいと思って対象外としています。

プロダクトコードの中でドメインロジックと開発都合のコードが混ざるとわかりにくくなりそうなので、こういう方法の方がベターかな、と考えました。

> `signin_steps` で mock を作っている箇所で...

についてはコメント参照
https://github.com/yochiyochirb/kajaeru/pull/128#issuecomment-193702497
https://github.com/yochiyochirb/kajaeru/pull/128#issuecomment-193720330

## 対応する issue

connects to #127