### PR TITLE
プルリクエストのテンプレートのコメントにある例に実際の issue への参照があるのを削除

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ## 対応する issue
 
 <!--
-connects to #123 みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
+connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
 -->
 
 connects to #


### PR DESCRIPTION
## やったこと

プルリクエストのテンプレートに `connects to` の例を書いていましたが、コメントなので実際には見えないけど Waffle は拾ってしまうため、消し忘れると誤った Issue に紐付けされてしまっていました。

なので実際の issue を参照しないようにしました。

## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

connects to #
