### PR TITLE
Fixturesを利用するようにした [closes #132]

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,66 +2,15 @@
 # TODO FactoryGirl 使うようになったら、これぜんぶ factory にして、
 #      FactoryGirl.create(:member)
 #      みたいにインスタンスを作るコードが書いてある rake タスクを作りたいなー。
-def reset_table(model)
-  model.delete_all
-  table_name = model.table_name
+require 'active_record/fixtures'
 
-  case ActiveRecord::Base.connection.adapter_name
-  when 'SQLite'
-    update_seq_sql = "update sqlite_sequence set seq = 0 where name = '#{table_name}';"
+if Rails.env.development?
+  # Create records from fixtures
+  fixtures_folder = File.join(Rails.root, 'features', 'fixtures')
 
-    ActiveRecord::Base.connection.execute(update_seq_sql)
-  when 'PostgreSQL'
-    ActiveRecord::Base.connection.reset_pk_sequence!(table_name)
-  else
-    raise 'Only SQLite and PostgreSQL can be reset.'
+  fixtures = Dir[File.join(fixtures_folder, '*.yml')].map do |f|
+    File.basename(f, '.yml')
   end
+
+  ActiveRecord::FixtureSet.create_fixtures(fixtures_folder, fixtures)
 end
-
-Member.transaction do
-  # NOTE truncate するのではなくdelete_allしてプライマリーキーだけ戻すようにする
-  [Member, Role].each { |klass| reset_table(klass) }
-
-  members = [
-    { account: 'alice',   uid: '11111', image: 'http://pic.prepics-cdn.com/9ece34e247cc4/54052408.jpeg' },
-    { account: 'bob',     uid: '22222', image: 'http://pic.prepics-cdn.com/9ece34e247cc4/54052407.jpeg' },
-    { account: 'charlie', uid: '33333', image: 'http://pic.prepics-cdn.com/9ece34e247cc4/54052406.jpeg' },
-    { account: 'john',    uid: '44444', image: 'http://pic.prepics-cdn.com/aee2982c9f207/53480916.jpeg' },
-    { account: 'doe',     uid: '55555', image: 'http://pic.prepics-cdn.com/aee2982c9f207/53480915.jpeg' },
-  ]
-
-  members.each do |member|
-    Member.create!(
-      nickname: member[:account], 
-      provider: 'github',
-      uid:      member[:uid],
-      image:    member[:image]
-    )
-  end
-
-  Member.all.map do |member|
-    %w(candidate voter).map {|klass| klass.classify.constantize }
-      .each do |klass|
-        klass.create!(member_id: member.id)
-      end
-  end
-end
-
-#Vote.transaction do
-#  Vote.delete_all
-#  votes = [
-#    { voting_account: 'ManabuSeki', voted_account: 'marcoball', comment: ('あ'..'ん').to_a.join },
-#    { voting_account: 'maruyu0622', voted_account: 'odaillyjp', comment: '!@#$%^&*()_+-=\][{}|";:/.,<>?~`' },
-#    { voting_account: 'kanpou0108', voted_account: 'odaillyjp', comment: ('a'..'z').to_a.join },
-#    { voting_account: 'umekumi',    voted_account: 'marcoball', comment: (0..9).to_a.join },
-#    { voting_account: 'ikepon',     voted_account: 'odaillyjp', comment: '噂浬欺圭構蚕十申曾箪貼能表暴予禄兔喀媾彌拿杤歃濬畚秉綵臀藹觸軆鐔饅鷭偆砡' },
-#    { voting_account: 'axross',     voted_account: 'katorie',   comment: ('ア'..'ン').to_a.join }
-#  ]
-#  votes.each do |vote|
-#    Vote.create!(
-#      comment:          vote[:comment],
-#      voted_member_id:  Member.find_by(nickname: vote[:voted_account]).id,
-#      voting_member_id: Member.find_by(nickname: vote[:voting_account]).id
-#    )
-#  end
-#end

--- a/features/fixtures/members.yml
+++ b/features/fixtures/members.yml
@@ -1,0 +1,32 @@
+DEFAULTS: &DEFAULTS
+  provider: github
+
+alice:
+  <<: *DEFAULTS
+  nickname: alice
+  uid: 11111
+  image: http://pic.prepics-cdn.com/9ece34e247cc4/54052408.jpeg
+
+bob:
+  <<: *DEFAULTS
+  nickname: bob
+  uid: 22222
+  image: http://pic.prepics-cdn.com/9ece34e247cc4/54052407.jpeg
+
+charlie:
+  <<: *DEFAULTS
+  nickname: charlie
+  uid: 33333
+  image: http://pic.prepics-cdn.com/9ece34e247cc4/54052406.jpeg
+
+john:
+  <<: *DEFAULTS
+  nickname: john
+  uid: 44444
+  image: http://pic.prepics-cdn.com/aee2982c9f207/53480916.jpeg
+
+doe:
+  <<: *DEFAULTS
+  nickname: doe
+  uid: 55555
+  image: http://pic.prepics-cdn.com/aee2982c9f207/53480915.jpeg

--- a/features/fixtures/roles.yml
+++ b/features/fixtures/roles.yml
@@ -1,0 +1,39 @@
+alice_candidate:
+  type: Candidate
+  member: alice
+
+alice_voter:
+  type: Voter
+  member: alice
+
+bob_candidate:
+  type: Candidate
+  member: bob
+
+bob_voter:
+  type: Voter
+  member: bob
+
+charlie_candidate:
+  type: Candidate
+  member: charlie
+
+charlie_voter:
+  type: Voter
+  member: charlie
+
+john_candidate:
+  type: Candidate
+  member: john
+
+john_voter:
+  type: Voter
+  member: john
+
+doe_candidate:
+  type: Candidate
+  member: doe
+
+doe_voter:
+  type: Voter
+  member: doe

--- a/features/step_definitions/signin_steps.rb
+++ b/features/step_definitions/signin_steps.rb
@@ -1,5 +1,5 @@
 前提(/^GitHub アカウント "([^"]*)" でログインしている$/) do |account|
-  member = Member.find_by!(nickname: account)
+  member = members(account)
 
   OmniAuth.config.test_mode = true
 


### PR DESCRIPTION
## やったこと

fixtures を利用するように修正しました。

- `members` と `roles` の fixtures を定義した
- Cucumber から fixtures とヘルパー (例: `members(:alice)`) を使えるようにした ([ここ](https://github.com/cucumber/cucumber/wiki/Fixtures)からのコピペです)
- seeds も fixtures から読み込むようにした (development のみ)

#131 を修正しないとテストが通りません。

## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

connects to #132 
