### PR TITLE
ENV['GITHUB_CLIENT_ID'] と ENV['GITHUB_CLIENT_SECRET'] の用途についての補足コメントを追加した

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,9 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
+  # NOTE 開発時に GitHub の OAuth application の登録が必須だと大変なので、
+  #      development 環境では実際に認証は行わない。
+  #      そのため、development 環境で動かすだけであれば、
+  #      GitHub 認証をする際に必要となる ENV['GITHUB_CLIENT_ID'] と ENV['GITHUB_CLIENT_SECRET'] には
+  #      token の値が入っていない状態でかまわない。
   provider :github, ENV['GITHUB_CLIENT_ID'], ENV['GITHUB_CLIENT_SECRET']
 
   # NOTE 開発時に GitHub の OAuth application の登録が必須だと大変なので、


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->

## やったこと

開発環境構築手順が変わったことで、 `ENV['GITHUB_CLIENT_ID']` と `ENV['GITHUB_CLIENT_SECRET'] ` の扱いについてのコンテキストが失われないように、コメントを追加しました。

via https://github.com/yochiyochirb/kajaeru/pull/128#discussion_r55905499

慣れていらっしゃるかたには冗長に感じられる箇所もあるかとは思うのですが、毎回のミートアップの環境構築フローではできるだけ参加者のみなさまの「おかしいな？？」と思う部分をなくして開発に専念したい、というのがわたしの率直な気持ちなので、入れさせていただきました。

## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

なし