### PR TITLE
Cucumber の実行時にも fixtures を読み込むようにした [closes #132]

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -55,3 +55,13 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
+
+Before do
+  # NOTE Cucumber でも fixtures を読み込む
+  ActiveRecord::FixtureSet.reset_cache
+  fixtures_folder = File.join(Rails.root, 'test', 'fixtures')
+  fixtures = Dir[File.join(fixtures_folder, '*.yml')].map do |f|
+    File.basename(f, '.yml')
+  end
+  ActiveRecord::FixtureSet.create_fixtures(fixtures_folder, fixtures)
+end


### PR DESCRIPTION
## やったこと

`env.rb` に fixtures を読み込むコードを追加して Cucumber の実行時にも fixtures のレコードを使うようにしました。

これにより、

- Minitest のテスト実行時 `bin/rails test` 
- Cucumberのテスト実行時 `bundle exec cucumber`

のどちらの場合も同じ fixtures が使われるようになり、事前に `bin/rails db:create RAILS_ENV=test` や `bin/rails db:fixtures:load RAILS_ENV=test` や `bin/rails db:seed RAILS_ENV=test` などを行う必要がなくなります。

## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

connects to #132