### PR TITLE
binding_of_caller と better_errors を（問題が解決するまで）使わない [closes #159]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,6 @@ group :doc do
 end
 
 group :development do
-  gem 'better_errors'
-  gem 'binding_of_caller'
   gem 'figaro'
   gem 'listen', '~> 3.0.5'
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,12 +43,6 @@ GEM
     arel (7.0.0)
     autoprefixer-rails (6.3.5)
       execjs
-    better_errors (2.1.1)
-      coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
-      rack (>= 0.9.0)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -278,8 +272,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  better_errors
-  binding_of_caller
   bootstrap-sass
   byebug
   coffee-rails (~> 4.1.0)


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->

## やったこと

#159 に書いてもらっているとおり、レンダリングされるまでにだいぶ時間がかかるようになってしまっているようです。

https://github.com/charliesome/better_errors/issues/341
https://github.com/banister/binding_of_caller/issues/59

わたし自身も、開発していてちょっとリズムをくずされるなあというかんじがけっこうするので、いったん抜いてみました。

## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

connects to #159