### PR TITLE
Hound が HtmlAttributes に文句を言うのをやめさせた

### DIFF
--- a/.haml-style.yml
+++ b/.haml-style.yml
@@ -23,7 +23,7 @@ linters:
     enabled: true
 
   HtmlAttributes:
-    enabled: true
+    enabled: false
 
   ImplicitDiv:
     enabled: true

--- a/.haml-style.yml
+++ b/.haml-style.yml
@@ -1,0 +1,70 @@
+# Whether to ignore frontmatter at the beginning of HAML documents for
+# frameworks such as Jekyll/Middleman
+skip_frontmatter: false
+
+linters:
+  AltText:
+    enabled: false
+
+  ClassAttributeWithStaticValue:
+    enabled: true
+
+  ClassesBeforeIds:
+    enabled: true
+
+  ConsecutiveComments:
+    enabled: true
+
+  ConsecutiveSilentScripts:
+    enabled: true
+    max_consecutive: 2
+
+  EmptyScript:
+    enabled: true
+
+  HtmlAttributes:
+    enabled: true
+
+  ImplicitDiv:
+    enabled: true
+
+  LeadingCommentSpace:
+    enabled: true
+
+  LineLength:
+    enabled: true
+    max: 80
+
+  MultilinePipe:
+    enabled: true
+
+  MultilineScript:
+    enabled: true
+
+  ObjectReferenceAttributes:
+    enabled: true
+
+  RuboCop:
+    enabled: false
+
+  RubyComments:
+    enabled: true
+
+  SpaceBeforeScript:
+    enabled: true
+
+  SpaceInsideHashAttributes:
+    enabled: true
+    style: space
+
+  TagName:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  UnnecessaryInterpolation:
+    enabled: true
+
+  UnnecessaryStringOutput:
+    enabled: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -2,3 +2,5 @@ ruby:
   config_file: .ruby-style.yml
 scss:
   config_file: .scss-style.yml
+haml:
+  config_file: .haml-style.yml


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->

## やったこと

Hound が [HtmlAttributes](https://github.com/brigade/haml-lint/tree/master/lib/haml_lint/linter#htmlattributes) に文句を言わないようにした。

refs : 
https://github.com/yochiyochirb/kajaeru/pull/164#discussion_r58485615
https://github.com/yochiyochirb/kajaeru/pull/164#discussion_r58486633

テストのやり方がよくわからなかったので、 `.haml-style.yml` を変えながら何回か git push して期待通りに haml-lint の HtmlAttributes が無効になっていることを確認しました。

## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

nothing