### PR TITLE
API 呼び出しで作った Member データに Role を付与する

### DIFF
--- a/lib/batch/insert_to_members_from_github_contributors.rb
+++ b/lib/batch/insert_to_members_from_github_contributors.rb
@@ -23,7 +23,5 @@ end
 
 Member.all.map do |member|
   %w(candidate voter).map { |klass| klass.classify.constantize }
-    .each do |klass|
-      klass.create!(member_id: member.id)
-    end
+                     .each { |klass| klass.create!(member_id: member.id) }
 end

--- a/lib/batch/insert_to_members_from_github_contributors.rb
+++ b/lib/batch/insert_to_members_from_github_contributors.rb
@@ -20,3 +20,10 @@ contributors.each do |contributor|
     uid: author['id'].to_s,
     image: author['avatar_url'])
 end
+
+Member.all.map do |member|
+  %w(candidate voter).map {|klass| klass.classify.constantize }
+    .each do |klass|
+      klass.create!(member_id: member.id)
+    end
+end

--- a/lib/batch/insert_to_members_from_github_contributors.rb
+++ b/lib/batch/insert_to_members_from_github_contributors.rb
@@ -22,7 +22,7 @@ contributors.each do |contributor|
 end
 
 Member.all.map do |member|
-  %w(candidate voter).map {|klass| klass.classify.constantize }
+  %w(candidate voter).map { |klass| klass.classify.constantize }
     .each do |klass|
       klass.create!(member_id: member.id)
     end

--- a/lib/batch/insert_to_members_from_github_contributors.rb
+++ b/lib/batch/insert_to_members_from_github_contributors.rb
@@ -22,6 +22,8 @@ contributors.each do |contributor|
 end
 
 Member.all.map do |member|
-  %w(candidate voter).map { |klass| klass.classify.constantize }
-                     .each { |klass| klass.create!(member_id: member.id) }
+  [Candidate, Voter].each do |klass|
+    next if klass.find_by(member_id: member.id)
+    klass.create!(member_id: member.id)
+  end
 end


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->

## やったこと

https://idobata.io/ja/archives/organization/yochiyochirb/room/kaja/2016-04-16#message_15416607

staging 及び production で動かす際には GitHub API 経由でメンバーのデータを取得してきますが、そのメンバーに対して `Vote` `Candidate` の role を付与する処理が抜けていたので、アプリケーション内で期待しない動作をしていました。
よって、 API 呼び出し時にそれら role を付与する処理を追加しました。

## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

なし