### PR TITLE
バッチの実行時にイベントが role に指定されずエラーになる問題を修正

### DIFF
--- a/lib/batch/insert_to_members_from_github_contributors.rb
+++ b/lib/batch/insert_to_members_from_github_contributors.rb
@@ -1,13 +1,26 @@
 require 'open-uri'
 
+unless ARGV[0]
+  puts <<-EOS
+イベントが指定されていません。引数でイベントを指定してください。
+例) bin/rails runner lib/batch/insert_to_members_from_github_contributors.rb "Ruby Kaja 2016"
+  EOS
+  exit 1
+end
+
 res = open('https://api.github.com/repos/yochiyochirb/meetups/stats/contributors')
 
 # res.status => ["200", "OK"]
-status, msg = res.status 
+status, msg = res.status
 
 unless status == '200'
   puts "STATUS CODE: #{status}, MESSAGE: #{msg}"
   exit
+end
+
+# コマンドライン引数で指定したイベント名でイベントを作る
+unless event = Event.find_by(name: ARGV[0])
+  event = Event.create!(name: ARGV[0])
 end
 
 contributors = ActiveSupport::JSON.decode res.read
@@ -24,6 +37,6 @@ end
 Member.all.map do |member|
   [Candidate, Voter].each do |klass|
     next if klass.find_by(member_id: member.id)
-    klass.create!(member_id: member.id)
+    klass.create!(member_id: member.id, event: event)
   end
 end


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->

## やったこと

バッチの実行時にイベントが role に指定されずエラーになる問題を修正しました。
バッチのコマンドライン引数でイベント名を指定することで、
そのイベントが作られて voter / candidate の外部キーに設定されます。


例)
```
bin/rails runner lib/batch/insert_to_members_from_github_contributors.rb "Ruby Kaja 2016"
```


## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

なし